### PR TITLE
fix: scope regexp

### DIFF
--- a/lib/scopeify-selectors.js
+++ b/lib/scopeify-selectors.js
@@ -111,7 +111,7 @@ function convertToClass(selector) {
 }
 
 function findPartialSelector(partialSelector) {
-  return new RegExp('\\b' + partialSelector + '\\b');
+  return new RegExp('^\\b' + partialSelector + '\\b$');
 }
 
 function splitAttributeSelectors(selector) {


### PR DESCRIPTION
/\bicon-list\b/     .icon-list .icon => .icon_hash-list_hash .icon ❌
/^\bicon-list\b$/     .icon-list .icon => .icon-list_hash .icon_hash ✅
